### PR TITLE
feat: native send check

### DIFF
--- a/src/contracts/RefTokenBridge.sol
+++ b/src/contracts/RefTokenBridge.sol
@@ -201,6 +201,7 @@ contract RefTokenBridge is IRefTokenBridge {
 
     // RefToken supply to burn on this chain
     bool _isNativeAssetChain = block.chainid == _nativeAssetChainId;
+    if (_isNativeAssetChain && _token != _refTokenMetadata.nativeAsset) revert RefTokenBridge_NotNativeAsset();
     if (!_isNativeAssetChain && _token != _refToken) revert RefTokenBridge_NotRefToken();
 
     // If the chain is the native asset chain, lock the native asset

--- a/test/unit/RefTokenBridge.t.sol
+++ b/test/unit/RefTokenBridge.t.sol
@@ -143,6 +143,37 @@ contract RefTokenBridgeUnit is Helpers {
     refTokenBridge.send(_nativeAssetChainId, _relayChainId, _nativeAsset, _amount, _recipient);
   }
 
+  function test_SendRevertWhen_NativeChainIdMatchesTheBlockChainIdAndTheTokenIsNotTheNativeToken(
+    address _caller,
+    uint256 _relayChainId,
+    address _nativeAsset,
+    address _refToken,
+    address _recipient,
+    uint256 _amount
+  ) external {
+    // Setup
+    _assumeFuzzable(_nativeAsset);
+    _assumeFuzzable(_refToken);
+    vm.assume(_nativeAsset != _refToken);
+
+    _amount = bound(_amount, 1, type(uint256).max);
+    _relayChainId = bound(_relayChainId, 1, type(uint256).max);
+    if (_relayChainId == block.chainid) ++_relayChainId;
+
+    vm.assume(_recipient != address(0));
+
+    refTokenBridge.setRefTokenDeployed(_refToken, true);
+
+    refTokenMetadata.nativeAsset = _nativeAsset;
+    refTokenMetadata.nativeAssetChainId = block.chainid;
+    _mockAndExpect(_refToken, abi.encodeCall(IRefToken.metadata, ()), abi.encode(refTokenMetadata));
+
+    // Action and assertion
+    vm.prank(_caller);
+    vm.expectRevert(IRefTokenBridge.RefTokenBridge_NotNativeAsset.selector);
+    refTokenBridge.send(block.chainid, _relayChainId, _refToken, _amount, _recipient);
+  }
+
   function test_SendRevertWhen_NativeChainIdIsNotDoesNotMatchTheBlockChainIdAndTheTokenIsNotTheRefToken(
     address _caller,
     uint256 _relayChainId,
@@ -527,6 +558,44 @@ contract RefTokenBridgeUnit is Helpers {
     _nativeAssetChainId = 0;
     vm.expectRevert(IRefTokenBridge.RefTokenBridge_InvalidNativeAssetChainId.selector);
     refTokenBridge.sendAndExecute(_nativeAssetChainId, _relayChainId, _token, _amount, _recipient, _executionData);
+  }
+
+  function test_SendAndExecuteRevertWhen_NativeChainIdMatchesTheBlockChainIdAndTheTokenIsNotTheNativeToken(
+    address _caller,
+    uint256 _relayChainId,
+    address _nativeAsset,
+    address _refToken,
+    address _recipient,
+    uint256 _amount,
+    IRefToken.RefTokenMetadata memory _refTokenMetadata,
+    IRefTokenBridge.ExecutionData memory _executionData
+  ) external {
+    // Setup
+    _assumeFuzzable(_nativeAsset);
+    _assumeFuzzable(_refToken);
+    vm.assume(_nativeAsset != _refToken);
+
+    _amount = bound(_amount, 1, type(uint256).max);
+    _relayChainId = bound(_relayChainId, 1, type(uint256).max);
+    if (_relayChainId == block.chainid) ++_relayChainId;
+
+    _refTokenMetadata.nativeAsset = _nativeAsset;
+    _refTokenMetadata.nativeAssetChainId = block.chainid;
+
+    vm.assume(_recipient != address(0));
+    vm.assume(_executionData.destinationExecutor != address(0));
+    vm.assume(_executionData.destinationChainId != block.chainid);
+    vm.assume(_executionData.destinationChainId != 0);
+    vm.assume(_executionData.refundAddress != address(0));
+
+    refTokenBridge.setRefTokenDeployed(_refToken, true);
+
+    _mockAndExpect(_refToken, abi.encodeCall(IRefToken.metadata, ()), abi.encode(_refTokenMetadata));
+
+    // Action and assertion
+    vm.prank(_caller);
+    vm.expectRevert(IRefTokenBridge.RefTokenBridge_NotNativeAsset.selector);
+    refTokenBridge.sendAndExecute(block.chainid, _relayChainId, _refToken, _amount, _recipient, _executionData);
   }
 
   function test_SendAndExecuteRevertWhen_NativeChainIdIsNotDoesNotMatchTheBlockChainIdAndTheTokenIsNotTheRefToken(

--- a/test/unit/RefTokenBridge.tree
+++ b/test/unit/RefTokenBridge.tree
@@ -11,6 +11,8 @@ RefTokenBridgeUnit::send
 │   └── It should revert
 ├── When native asset chain id is zero
 │   └── It should revert
+├── When native chain id matches the block chain id and the token is not the native token
+│   └── It should revert
 ├── When native chain id is not does not match the block chain id and the token is not the ref token
 │   └── It should revert
 ├── When called with a native token first time
@@ -47,6 +49,8 @@ RefTokenBridgeUnit::sendAndExecute
 ├── When native asset chain id does not match the block chain id when deploying a RefToken
 │   └── It should revert
 ├── When native asset chain id is zero
+│   └── It should revert
+├── When native chain id matches the block chain id and the token is not the native token
 │   └── It should revert
 ├── When native chain id is not does not match the block chain id and the token is not the ref token
 │   └── It should revert


### PR DESCRIPTION
Added to avoid a user setting the `_refToken` as input on the native asset chain, and weirdly getting the native asset locked or fail due to insufficient allowance.